### PR TITLE
외부 인프라 없이 동시성을 제어한다

### DIFF
--- a/core/core-domain/src/main/java/com/nmh/commerce/coupon/CouponStockManager.java
+++ b/core/core-domain/src/main/java/com/nmh/commerce/coupon/CouponStockManager.java
@@ -12,16 +12,10 @@ import java.util.concurrent.locks.ReentrantLock;
 @Component
 public class CouponStockManager {
     private final CouponStockRepository stockRepository;
-    private final Lock lock = new ReentrantLock();
 
-    public CouponStock deductStock(Long couponId) {
-        lock.lock();
-        try {
+    public synchronized CouponStock deductStock(Long couponId) {
         CouponStock stock = stockRepository.findByCouponId(couponId)
             .orElseThrow(() -> new IllegalArgumentException("해당 쿠폰 재고 정보를 찾을 수 없습니다."));
         return stockRepository.save(stock.deductQuantity());
-        } finally {
-            lock.unlock();
-        }
     }
 }

--- a/core/core-domain/src/main/java/com/nmh/commerce/coupon/CouponStockManager.java
+++ b/core/core-domain/src/main/java/com/nmh/commerce/coupon/CouponStockManager.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -12,10 +14,17 @@ import java.util.concurrent.locks.ReentrantLock;
 @Component
 public class CouponStockManager {
     private final CouponStockRepository stockRepository;
+    private final Map<Long, Lock> lockMap = new ConcurrentHashMap<>();
 
-    public synchronized CouponStock deductStock(Long couponId) {
-        CouponStock stock = stockRepository.findByCouponId(couponId)
-            .orElseThrow(() -> new IllegalArgumentException("해당 쿠폰 재고 정보를 찾을 수 없습니다."));
-        return stockRepository.save(stock.deductQuantity());
+    public CouponStock deductStock(Long couponId) {
+        Lock lock = lockMap.computeIfAbsent(couponId, id -> new ReentrantLock());
+        lock.lock();
+        try {
+            CouponStock stock = stockRepository.findByCouponId(couponId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 쿠폰 재고 정보를 찾을 수 없습니다."));
+            return stockRepository.save(stock.deductQuantity());
+        } finally {
+            lock.unlock();
+        }
     }
 }

--- a/core/core-domain/src/main/java/com/nmh/commerce/coupon/CouponStockManager.java
+++ b/core/core-domain/src/main/java/com/nmh/commerce/coupon/CouponStockManager.java
@@ -4,15 +4,24 @@ import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
 @Builder
 @RequiredArgsConstructor
 @Component
 public class CouponStockManager {
     private final CouponStockRepository stockRepository;
+    private final Lock lock = new ReentrantLock();
 
     public CouponStock deductStock(Long couponId) {
+        lock.lock();
+        try {
         CouponStock stock = stockRepository.findByCouponId(couponId)
             .orElseThrow(() -> new IllegalArgumentException("해당 쿠폰 재고 정보를 찾을 수 없습니다."));
         return stockRepository.save(stock.deductQuantity());
+        } finally {
+            lock.unlock();
+        }
     }
 }


### PR DESCRIPTION
# 동시성 제어 해보기

> **외부 인프라(DB, Redis 등)를 사용하지 않고, 순수 자바(JVM 수준)로 동시성 문제를 제어하는 방법 실습**

## ✅ 목표
- 하나의 쿠폰 재고(100개)에 대해 100명이 동시에 차감 요청을 보낼 경우,
- **정확히 100개가 모두 차감되어 재고가 0이 되는지** 검증

## 🧪 테스트 시나리오
- 고정된 32개의 스레드 풀을 가진 `ExecutorService`를 사용하여 100개의 요청을 병렬로 발생
- 각 요청은 `couponStockManager.deductStock(2L)` 호출
- 모든 요청 완료 후 재고가 정확히 0인지 `assert`로 검증

## 🧠 가정한 상황
- 인기 있는 쿠폰을 수백 명이 동시에 사용하려고 하는 이벤트 상황
- 여러 스레드가 하나의 공유 자원(`CouponStock`)을 동시에 수정하려고 할 때 발생할 수 있는 **Race Condition**을 방지하고자 함

## 🔒 실험한 동시성 제어 방법 비교

| 방법 | 재고 정확도 | 병렬성 | 코드 난이도 | 설명 |
|------|--------------|--------|---------------|------|
| `synchronized` | ✅ 정확 | ❌ 낮음 (전역 락) | ✅ 쉬움 | 가장 단순한 방법. 모든 쿠폰 요청이 하나의 락을 공유해서 병목 발생 |
| `ReentrantLock (전역)` | ✅ 정확 | ❌ 낮음 (전역 락) | ✅ 중간 | 명시적인 락/해제가 가능하나, 병렬성은 낮음 |
| `ReentrantLock + ConcurrentHashMap` | ✅ 정확 | ✅ 높음 (ID별 병렬 처리) | ❌ 약간 복잡 | 쿠폰 ID별로 락을 분리해서 병렬성 확보. 가장 확장성 있는 구조 |

> 💡 **실험 결과**, 세 방법 모두 재고를 정확히 0으로 줄이는 데는 성공했지만,  
> **`ReentrantLock + ConcurrentHashMap` 방식이 병렬 처리와 확장성 측면에서 가장 이상적**이라는 판단 하에 해당 방식으로 최종 선택하였습니다.

---

## 🔒 동시성 제어 방식
- `ReentrantLock`을 사용해 **동기화 블록을 명확하게 제어**
- 쿠폰 ID별로 락을 분리하기 위해 `ConcurrentHashMap<Long, Lock>` 활용
    - 각 쿠폰 ID마다 고유한 락을 가지도록 하여 병렬성을 확보
    - 단일 락을 사용하는 구조보다 성능과 확장성 측면에서 유리

## ✅ 기대 효과
- 여러 쿠폰에 대해 동시에 재고 차감이 들어와도 **쿠폰 ID별로 병렬 처리 가능**
- 테스트 상 재고가 정확히 0이 된다면, **동시성 제어가 정상적으로 작동한 것**으로 판단 가능

## 📝 기타 참고
- 이 PR에서는 순수 자바 레벨의 동기화만 사용했습니다. 추후에는 다음과 같은 방식과 비교 실험해볼 수 있습니다:
    - 낙관적 락 또는 비관적 락
    - Redis 기반 분산 락 (Lettuce 기반 Spin Lock, Redisson의 Pub/Sub 기반 락)