### PR TITLE
Testcontainers를 활용한 MySQL 인덱스 성능 테스트 추가

### DIFF
--- a/infrastructure/db-core/build.gradle.kts
+++ b/infrastructure/db-core/build.gradle.kts
@@ -7,6 +7,9 @@ dependencies {
     implementation(project(":common"))
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     runtimeOnly("com.h2database:h2")
+    testImplementation("org.testcontainers:mysql")
+    testImplementation("org.testcontainers:junit-jupiter")
+    implementation("mysql:mysql-connector-java:8.0.33")
 }
 
 allOpen {

--- a/infrastructure/db-core/src/test/kotlin/com/nmh/commerce/learning/MySQLIndexPerformanceTest.kt
+++ b/infrastructure/db-core/src/test/kotlin/com/nmh/commerce/learning/MySQLIndexPerformanceTest.kt
@@ -1,0 +1,166 @@
+package com.nmh.commerce.learning
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.assertj.core.api.BDDAssertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.sql.Connection
+import javax.sql.DataSource
+import kotlin.system.measureNanoTime
+
+@Testcontainers
+class MySQLIndexPerformanceTest {
+
+    @Container
+    private val mysql = MySQLContainer("mysql:8.0")
+        .withDatabaseName("test")
+        .withUsername("root")
+        .withPassword("root")
+
+    private lateinit var dataSource: DataSource
+
+    @BeforeEach
+    fun setUp() {
+        dataSource = HikariDataSource(
+            HikariConfig().apply {
+                jdbcUrl = mysql.jdbcUrl
+                username = mysql.username
+                password = mysql.password
+                maximumPoolSize = 5
+            },
+        )
+
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("DROP TABLE IF EXISTS user")
+                stmt.execute(
+                    """
+                    CREATE TABLE user (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        name VARCHAR(255),
+                        email VARCHAR(255),
+                        age INT,
+                        created_at DATETIME
+                    )
+                    """.trimIndent(),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `인덱스가 없을 때와 있을 때 쿼리 속도 비교`() {
+        dataSource.connection.use { conn ->
+            val insertSQL = "INSERT INTO user (name, email, age, created_at) VALUES (?, ?, ?, NOW())"
+            conn.prepareStatement(insertSQL).use { ps ->
+                for (i in 1..1_000) {
+                    ps.setString(1, "User$i")
+                    ps.setString(2, "user$i@example.com")
+                    ps.setInt(3, i % 100)
+                    ps.addBatch()
+                    if (i % 100 == 0) ps.executeBatch()
+                }
+                ps.executeBatch()
+            }
+
+            val noIndexTimeNs = measureQueryTimeNano(conn, "SELECT * FROM user WHERE email = 'user500@example.com'")
+            println("No index time: $noIndexTimeNs ns (${noIndexTimeNs / 1_000_000.0} ms)")
+
+            conn.createStatement().execute("CREATE INDEX idx_user_email ON user (email)")
+
+            val withIndexTimeNs = measureQueryTimeNano(conn, "SELECT * FROM user WHERE email = 'user500@example.com'")
+            println("With index time: $withIndexTimeNs ns (${withIndexTimeNs / 1_000_000.0} ms)")
+
+            BDDAssertions.then(withIndexTimeNs).isLessThan(noIndexTimeNs)
+        }
+    }
+
+    @Test
+    fun `복합 인덱스를 사용할 때 인덱스 순서에 맞게 사용해야한다`() {
+        dataSource.connection.use { conn ->
+            conn.createStatement().use { stmt ->
+                stmt.execute("DROP TABLE IF EXISTS user")
+                stmt.execute(
+                    """
+                CREATE TABLE user (
+                    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                    name VARCHAR(255),
+                    age INT,
+                    created_at DATETIME
+                )
+                    """.trimIndent(),
+                )
+            }
+
+            val insertSQL = "INSERT INTO user (name, age, created_at) VALUES (?, ?, NOW())"
+            conn.prepareStatement(insertSQL).use { ps ->
+                for (i in 1..1000) {
+                    ps.setString(1, "User${i % 100}") // name은 100종류
+                    ps.setInt(2, i % 50) // age는 50종류
+                    ps.addBatch()
+                    if (i % 100 == 0) ps.executeBatch()
+                }
+                ps.executeBatch()
+            }
+
+            // 인덱스가 없는 상태에서 쿼리 성능 측정
+            val noIndexTime = measureQueryTimeNano(conn, "SELECT * FROM user WHERE name = 'User10' AND age = 30")
+            println("No index time: $noIndexTime ns (${noIndexTime / 1_000_000.0} ms)")
+            printExplain(conn, "SELECT * FROM user WHERE name = 'User10' AND age = 30")
+
+            // 복합 인덱스를 (name, age) 순서로 설정
+            conn.createStatement().execute("CREATE INDEX idx_user_name_age ON user (name, age)")
+
+            // 잘못된 순서의 WHERE 조건 (age 먼저)
+            val wrongOrderTime = measureQueryTimeNano(conn, "SELECT * FROM user WHERE age = 30 AND name = 'User10'")
+            println("Wrong order (age first) time: $wrongOrderTime ns (${wrongOrderTime / 1_000_000.0} ms)")
+
+            // 올바른 순서의 WHERE 조건 (name 먼저)
+            val correctOrderTime = measureQueryTimeNano(conn, "SELECT * FROM user WHERE name = 'User10' AND age = 30")
+            println("Correct order (name first) time: $correctOrderTime ns (${correctOrderTime / 1_000_000.0} ms)")
+
+            printExplain(conn, "SELECT * FROM user WHERE age = 30 AND name = 'User10'")
+            printExplain(conn, "SELECT * FROM user WHERE name = 'User10' AND age = 30")
+
+            BDDAssertions.then(correctOrderTime).isLessThan(wrongOrderTime)
+            /*
+            항상 순서가 잘못되어있다고 해서 인덱스를 사용하지 않는 것은 아니다.
+            하지만 인덱스의 순서에 맞게 쿼리를 작성하는 것이 성능을 최적화하는 데 도움이 된다.
+
+            실제로 explain을 확인해보면 wrongOrderTime 쿼리는 인덱스를 사용하는 것으로 나온다
+            인덱스를 탈지 안탈지 여부는 내가 쿼리를 잘 작성하는 것과 연관은 없다.
+            물론 인덱스를 사용하도록 유도할 수 있지만 실제로 인덱스를 사용할지 사용하지 않을 지 선택하는 것은 MySQLd의 옵티마이저가 결정한다.
+             */
+        }
+    }
+
+    private fun measureQueryTimeNano(conn: Connection, query: String): Long = measureNanoTime {
+        conn.prepareStatement(query).use { ps ->
+            ps.executeQuery().use { rs ->
+                while (rs.next()) {
+                    /* Do nothing */
+                }
+            }
+        }
+    }
+
+    private fun printExplain(conn: Connection, query: String) {
+        println("EXPLAIN for query: $query")
+        conn.prepareStatement("EXPLAIN $query").use { ps ->
+            ps.executeQuery().use { rs ->
+                val meta = rs.metaData
+                val columnCount = meta.columnCount
+
+                while (rs.next()) {
+                    val row = (1..columnCount)
+                        .joinToString(", ") { idx -> "${meta.getColumnName(idx)}: ${rs.getString(idx)}" }
+                    println(row)
+                }
+            }
+        }
+    }
+}

--- a/infrastructure/db-core/src/test/kotlin/com/nmh/commerce/learning/TestContainerStartUpTest.kt
+++ b/infrastructure/db-core/src/test/kotlin/com/nmh/commerce/learning/TestContainerStartUpTest.kt
@@ -1,0 +1,41 @@
+package com.nmh.commerce.learning
+
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import java.sql.DriverManager
+
+@Testcontainers
+class TestContainerStartUpTest {
+
+    @Container
+    private val mysql = MySQLContainer((DockerImageName.parse("mysql:8.0")))
+        .withDatabaseName("test")
+        .withUsername("root")
+        .withPassword("root")
+
+    @Test
+    fun `MySQL 실행 테스트`() {
+        mysql.start()
+
+        val jdbcUrl = mysql.jdbcUrl
+        val username = mysql.username
+        val password = mysql.password
+
+        println("JDBC URL: $jdbcUrl")
+        println("Username: $username")
+        println("Password: $password")
+
+        DriverManager.getConnection(jdbcUrl, username, password).use { connection ->
+            val statement = connection.createStatement()
+            val resultSet = statement.executeQuery("SELECT 1")
+            if (resultSet.next()) {
+                println("MySQL is running!")
+            } else {
+                println("MySQL is not running!")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📌 주요 변경 사항

- **Testcontainers 기반 MySQL 성능 테스트 추가**
    - 인덱스 유무에 따른 쿼리 성능 비교
    - 복합 인덱스 사용 시 WHERE 조건 순서에 따른 성능 차이 확인
    - `EXPLAIN`을 활용하여 옵티마이저의 인덱스 선택 여부 확인

- **Gradle 설정 변경**
    - MySQL JDBC 드라이버 추가:
      ```kotlin
      implementation("mysql:mysql-connector-java:8.0.33")
      ```
    - Testcontainers 의존성 추가:
      ```kotlin
      testImplementation("org.testcontainers:mysql")
      testImplementation("org.testcontainers:junit-jupiter")
      ```
    - 기존 H2 의존성 유지 (`runtimeOnly("com.h2database:h2")`)
    - JPA 관련 `allOpen` 설정 유지:
      ```kotlin
      allOpen {
          annotation("javax.persistence.Entity")
          annotation("javax.persistence.MappedSuperclass")
          annotation("javax.persistence.Embeddable")
      }
      ```

---

## 🧪 추가된 테스트 목록

| 테스트 메서드 이름                                       | 설명                                      |
|--------------------------------------------------------|-------------------------------------------|
| `인덱스가 없을 때와 있을 때 쿼리 속도 비교`                | 인덱스 생성 전/후 동일 조건의 쿼리 성능 비교        |
| `복합 인덱스를 사용할 때 인덱스 순서에 맞게 사용해야한다`    | 복합 인덱스 (name, age) 사용 시 WHERE 절 순서에 따른 성능 차이 실험 및 옵티마이저 선택 확인 |

---

## 💎 확인 내용

- 인덱스 유무에 따른 **쿼리 성능 차이 확인**
- 복합 인덱스 생성 시 컬럼 순서와 WHERE 절 조건 순서가 일치하면 **성능 최적화 가능성 증가**
- 하지만 옵티마이저가 통계 정보를 바탕으로 실행 계획을 선택하기 때문에  
  **WHERE 조건 순서와 인덱스 순서가 항상 1:1 대응하지는 않음**
- `EXPLAIN` 결과를 통해 인덱스 사용 여부와 정렬 방식(filesort 등) 확인 가능

---

## 🧐 참고

- `COUNT(*)`, `GROUP BY`, `ORDER BY` 사용 시에도 커버링 인덱스 여부와 정렬 여부는 옵티마이저의 선택에 따라 달라질 수 있음
- 테스트 결과 출력 예시:
  ```
  No index time: 123456789 ns (123.456789 ms)
  With index time: 23456789 ns (23.456789 ms)
  ```
- `EXPLAIN` 결과 예시:
  ```
  id: 1, select_type: SIMPLE, table: user, type: ref, key: idx_user_email, key_len: 1023, ref: const, rows: 1, Extra: Using index
  ```

---

## ✅ 목적

- MySQL 옵티마이저가 인덱스를 어떻게 선택하는지 실험적으로 이해
- 인덱스 설계 시 WHERE 조건 순서와 인덱스 컬럼 순서의 관계 검증
- 실무에서 인덱스 최적화 시 참고할 수 있는 테스트 환경 구축

---
## 📚 인덱스 관련 정리

### 📌 복합 인덱스 (Composite Index)

- 여러 컬럼을 조합하여 하나의 인덱스를 생성하는 방식.

- 인덱스 생성 예시:

    ```sql
    CREATE INDEX idx_user_name_age_created_at ON user (name, age, created_at);
    ```

- **왼쪽 프리픽스 룰 (Leftmost Prefix Rule)**:

    - 인덱스의 왼쪽부터 연속된 컬럼만 사용할 수 있음.

    - 예: (name, age, created_at) → name만, name+age까지, 또는 name+age+created_at까지 사용 가능.


### 📌 커버링 인덱스 (Covering Index)

- 쿼리에서 필요한 **모든 컬럼이 인덱스에 포함**되어 있어 테이블 row를 읽지 않고 인덱스만으로 결과를 반환하는 방식.

- 장점:

    - 테이블 접근을 하지 않아 I/O 줄어듦 → 성능 향상.

- 예시:

    ```sql
    SELECT name, age, created_at FROM user WHERE name = 'User10';
    ```

  인덱스: (name, age, created_at) → 커버링 인덱스 사용 가능.


### ❌ 인덱스를 사용하지 않는 상황 (또는 비효율적으로 사용하는 경우)

|케이스|설명|예시|
|---|---|---|
|WHERE 조건이 인덱스 컬럼과 무관할 때|조건 컬럼이 인덱스에 없으면 풀스캔 (full table scan).|`WHERE non_indexed_column = 10`|
|Leftmost Prefix Rule가 깨질 때|인덱스 컬럼 중간만 사용할 경우 인덱스를 타지 못함.|인덱스: (name, age), 쿼리: `WHERE age = 30`|
|LIKE '%abc' 형태|문자열 앞에 와일드카드가 있을 경우 B+Tree 구조상 인덱스 사용 불가.|`WHERE name LIKE '%abc'`|
|컬럼 연산을 사용하는 경우|WHERE 절에서 함수나 연산을 사용하는 경우 인덱스 무효화.|`WHERE DATE(created_at) = '2024-01-01'`|
|NOT IN, NOT LIKE, != 연산자 사용|부정 연산자는 옵티마이저가 인덱스 사용을 피하게 만들 수 있음.|`WHERE age != 30`|
|옵티마이저가 풀스캔이 더 빠르다고 판단할 때|매우 작은 테이블 또는 결과 row 수가 많을 경우 풀스캔 선택.|작은 테이블에서 인덱스보다 풀스캔이 유리한 경우|
|통계 정보가 오래되어 잘못된 실행 계획이 선택된 경우|`ANALYZE TABLE`로 통계 갱신 필요, 통계 정보가 오래되면 옵티마이저 오판 가능.|`ANALYZE TABLE user;`|